### PR TITLE
수동출석이벤트를 마우스 커서가 다른 곳으로 옮겨지면 사라지는 기능

### DIFF
--- a/attendance_check/static/attendance_check/js/angular_script.js
+++ b/attendance_check/static/attendance_check/js/angular_script.js
@@ -403,10 +403,14 @@ app.controller('LectureAttendanceCheckController', function($scope, $http, $inte
           return $(title).children(".popover-heading").html();
         }});
         $('#specificControl_'+ id).popover('show');
-        // your code here
         return true;
     });
 
+    myDataView.attachEvent("onMouseOut", function (ev){
+        var id = currentSpecificControl;
+        $('#specificControl_'+ id).popover('hide');
+        return true;
+    });
 
 
      $scope.loadLectureList = function () {


### PR DESCRIPTION
수동출석이벤트를 해당 마우스 커서가 옮겨지면 사라지는 기능